### PR TITLE
Use Rx address type field from the scan response packet

### DIFF
--- a/CC_connection_req_crash.py
+++ b/CC_connection_req_crash.py
@@ -115,7 +115,7 @@ while True:
             timeout.cancel()
             print(Fore.GREEN + advertiser_address.upper() + ': ' + pkt.summary()[7:] + ' Detected')
             # Send connection request to advertiser
-            conn_request = BTLE() / BTLE_ADV(RxAdd=0, TxAdd=1) / BTLE_CONNECT_REQ(
+            conn_request = BTLE() / BTLE_ADV(RxAdd=pkt.TxAdd, TxAdd=1) / BTLE_CONNECT_REQ(
                 InitA=master_address,
                 AdvA=advertiser_address,
                 AA=access_address,  # Access address (any)


### PR DESCRIPTION
This change will uncover the Device Under Test (DUT) implementation behavior if the DUT is advertising with its RANDOM address type.