### PR TITLE
fix upper boundary check of knob attack

### DIFF
--- a/extras/knob_tester_ble.py
+++ b/extras/knob_tester_ble.py
@@ -242,7 +242,7 @@ while True:
             elif check_range(accepted_keys, 7, 15):
                 print(Fore.RED + 'Peripheral allows key entropy reduction. The key size range is '
                                  '[' + str(min(accepted_keys)) + ',' + str(max(accepted_keys)) + ']')
-            elif check_range(accepted_keys, 16, 17):
+            elif check_range(accepted_keys, 17, 17):
                 print(Fore.RED + 'Peripheral accepts key size greater than 16. Non-compliance!!!')
             elif check_range(accepted_keys, 16, 16) and not check_range(accepted_keys, 7, 15):
                 print(Fore.GREEN + 'Peripheral only accepts key size of 16. We are good to go!!!')


### PR DESCRIPTION
In the knob tester script there is a bug when checking values which are to big, the scripts tests for acutally valid values (16). With a bluetooth stack of only accepting 16 as key size the script claims falsley: _Peripheral accepts key size greater than 16. Non-compliance!!!_ 
The change fixed the check for values greater than 16. If only 16 is allowed as a keysize, the script now will output: _'Peripheral only accepts key size of 16. We are good to go!!!_